### PR TITLE
Request fresh last collection dates for missed bin reporting

### DIFF
--- a/bins/missed-collection.html
+++ b/bins/missed-collection.html
@@ -1191,7 +1191,8 @@ async function loadBinsForProperty() {
                 'x-api-token': 'oije8u23984uoriwfjowei2398470'
             },
             body: JSON.stringify({
-                addressId: addressId
+                addressId: addressId,
+                includeLastCollection: true  // Fresh, accurate last collection dates
             })
         });
         


### PR DESCRIPTION
Add includeLastCollection: true parameter to bins-by-uprn API call to ensure accurate, uncached last collection dates are used for eligibility checking