### PR TITLE
Remove .ics extension from webcal URL

### DIFF
--- a/bins/collection-day.html
+++ b/bins/collection-day.html
@@ -854,7 +854,7 @@ function setupCalendarButton() {
         }
 
         // Create webcal URL
-        const webcalUrl = `webcal://gcc-api-pilot.azurewebsites.net/api/bins-webcal/${currentAddressId}.ics`;
+        const webcalUrl = `webcal://gcc-api-pilot.azurewebsites.net/api/bins-webcal/${currentAddressId}`;
 
         // Show modal with instructions
         showCalendarInstructions(webcalUrl);


### PR DESCRIPTION
Change calendar subscription URL from bins-webcal/{addressId}.ics to bins-webcal/{addressId} to match updated API route